### PR TITLE
Fix SCSS import and add page TOC to nav panel

### DIFF
--- a/_includes/head_custom.html
+++ b/_includes/head_custom.html
@@ -1,0 +1,1 @@
+<script src="{{ '/assets/js/page-toc.js' | relative_url }}" defer></script>

--- a/_includes/nav_footer_custom.html
+++ b/_includes/nav_footer_custom.html
@@ -1,0 +1,4 @@
+<div id="page-toc-nav-container" class="page-toc-container">
+  <h3 class="text-delta">On this page</h3>
+  <nav id="page-toc-nav" class="nav-list"></nav>
+</div>

--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -1,11 +1,3 @@
----
-# Diese leere Front Matter ist alles, was Jekyll braucht.
----
-
-// Wichtig: Importiert die Standard-Styles des Themes.
-// Muss immer am Anfang stehen.
-@import "just-the-docs/just-the-docs";
-
 // Unser Container für das Seiten-TOC
 .page-toc-container {
   margin-top: 1rem;


### PR DESCRIPTION
- Restructured custom SCSS to use `_sass/custom/custom.scss` as recommended by just-the-docs, resolving the SCSS import error during GitHub Pages build.
- Added a Table of Contents (TOC) to the left navigation panel.
- The TOC is dynamically generated using JavaScript and lists H2 and H3 headings from the current page.
- Ensured the JavaScript for the TOC is loaded via `_includes/head_custom.html`.