### PR TITLE
Feat: Enhance sidebar ToC display and styling

### DIFF
--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -29,6 +29,7 @@
   font-weight: bold;
   font-size: 0.92em; // Slightly smaller than main nav items
   padding: 0.1rem 0;
+  padding-left: 0.5rem !important; // Base padding for H1
   display: block;
 }
 
@@ -44,6 +45,7 @@
 .page-toc-container .nav-list-item-level-2 > .nav-list-link {
   font-size: 0.9em;
   padding: 0.1rem 0;
+  padding-left: 1rem !important; // Indent H2
   display: block;
 }
 
@@ -60,6 +62,7 @@
   font-size: 0.88em;
   color: var(--jtc-text-color-light);
   padding: 0.1rem 0;
+  padding-left: 1.5rem !important; // Indent H3
   display: block;
 }
 
@@ -76,6 +79,7 @@
   font-size: 0.86em;
   color: var(--jtc-text-color-lighter);
   padding: 0.1rem 0;
+  padding-left: 2rem !important; // Indent H4
   display: block;
 }
 
@@ -92,6 +96,7 @@
   font-size: 0.84em;
   color: var(--jtc-text-color-lighter);
   padding: 0.1rem 0;
+  padding-left: 2.5rem !important; // Indent H5
   display: block;
 }
 
@@ -108,13 +113,14 @@
   font-size: 0.82em;
   color: var(--jtc-text-color-lighter);
   padding: 0.1rem 0;
+  padding-left: 3rem !important; // Indent H6
   display: block;
 }
 
 // Ensure links within TOC don't inherit global nav link styles that might conflict
 .page-toc-container .nav-list-link {
   border-left: none; // Override potential theme border on active/hover nav links
-  padding-left: 0.25rem; // Add some padding to the link text itself
+  // padding-left: 0.25rem; // This will be overridden by level specific padding-left
 }
 .page-toc-container .nav-list-link:hover,
 .page-toc-container .nav-list-link.active { // Assuming we might add 'active' on scroll

--- a/assets/js/page-toc.js
+++ b/assets/js/page-toc.js
@@ -105,13 +105,14 @@ document.addEventListener('DOMContentLoaded', function() {
     if (activeNavLink) {
       let parentLi = activeNavLink.closest('.nav-list-item');
       if (parentLi) {
-        // Insert the TOC container after the parent LI of the active link
-        parentLi.parentNode.insertBefore(tocWrapperDiv, parentLi.nextSibling);
+        // Insert the TOC container as the last child of the parent LI of the active link
+        parentLi.appendChild(tocWrapperDiv);
       } else {
         // Fallback: if somehow active link is not in an LI, append to sidebar nav container
         // This is unlikely with just-the-docs structure.
         // Or, could append to a default location if no active link found.
         // For now, if no parentLi, it won't be inserted.
+        // console.log("Page TOC: Active nav link found, but not within a .nav-list-item.");
       }
     } else {
       // Fallback: if no active link is found (e.g. on homepage not in nav),


### PR DESCRIPTION
- Modified page-toc.js to correctly nest the ToC under the active page in the sidebar.
- Updated custom.scss to add indentation to ToC items based on heading level, complementing existing font size and color styling.
- Verified that main navigation correctly displays page titles from front matter.