### PR TITLE
Refactor: Update sidebar ToC script to use specific #markdown-toc

### DIFF
--- a/_includes/head_custom.html
+++ b/_includes/head_custom.html
@@ -1,34 +1,67 @@
 <script>
 document.addEventListener("DOMContentLoaded", function () {
-  const toc = document.querySelector(".toc"); // Rechtes TOC
+  // Try to find the user's in-page ToC list first
+  const inPageTocList = document.querySelector("#markdown-toc");
   const sidebar = document.querySelector(".side-bar");
 
-  if (toc && sidebar) {
-    const clonedToc = toc.cloneNode(true);
-    clonedToc.classList.add("toc-in-sidebar");
+  if (inPageTocList && sidebar) {
+    // Found the user's #markdown-toc
+    const detailsParent = inPageTocList.closest('details');
 
-    // Optional: TOC-Titel
-    const tocTitle = document.createElement("h2");
-    tocTitle.innerText = "Inhalt"; // "Content" or "On this page" might be better English placeholder
-    tocTitle.classList.add("nav__title"); // This class might need adjustment based on theme's sidebar title styles
+    // Add class for styling to the ToC list itself
+    inPageTocList.classList.add("toc-in-sidebar");
 
-    // Container in Sidebar einfügen
-    const container = document.createElement("nav");
-    container.classList.add("nav-list", "nav-list--toc"); // Base classes for styling
-    container.appendChild(tocTitle);
-    container.appendChild(clonedToc);
+    // Create title and container for the sidebar
+    const tocTitleElement = document.createElement("h2");
+    tocTitleElement.innerText = "Inhalt"; // Or "On this page"
+    tocTitleElement.classList.add("nav__title");
 
-    // Later steps will refine this:
-    // sidebar.appendChild(container);
+    const tocContainerInSidebar = document.createElement("nav");
+    tocContainerInSidebar.classList.add("nav-list", "nav-list--toc");
+    tocContainerInSidebar.appendChild(tocTitleElement);
+    tocContainerInSidebar.appendChild(inPageTocList); // This moves inPageTocList
 
+    // Place container in the active sidebar item
     const activeListItem = sidebar.querySelector(".nav-list-item.active");
     if (activeListItem) {
-      activeListItem.appendChild(container);
-      document.body.classList.add("js-toc-sidebar"); // Add class to body if ToC is moved
+      activeListItem.appendChild(tocContainerInSidebar);
     } else {
-      sidebar.appendChild(container);
-      document.body.classList.add("js-toc-sidebar"); // Still add class if appended to sidebar end
-      console.warn("Cloned ToC: No active .nav-list-item found in sidebar. Appending ToC to end of sidebar.");
+      // Fallback: append to the end of the sidebar
+      sidebar.appendChild(tocContainerInSidebar);
+      console.warn("Sidebar ToC: No active .nav-list-item found. Appending ToC to end of sidebar.");
+    }
+
+    // Hide the original <details> block that contained the #markdown-toc
+    if (detailsParent) {
+      detailsParent.style.display = 'none';
+    }
+    document.body.classList.add("js-toc-sidebar"); // Used to hide other .toc elements via CSS
+
+  } else if (sidebar) {
+    // Fallback to original logic if #markdown-toc is not found, but .toc (theme's default) might exist
+    const themeToc = document.querySelector(".toc"); // Original selector for theme's .toc
+    if (themeToc) {
+      console.log("Sidebar ToC: #markdown-toc not found, attempting to use theme's .toc element.");
+      const clonedThemeToc = themeToc.cloneNode(true);
+      clonedThemeToc.classList.add("toc-in-sidebar");
+
+      const tocTitleElement = document.createElement("h2");
+      tocTitleElement.innerText = "Inhalt";
+      tocTitleElement.classList.add("nav__title");
+
+      const tocContainerInSidebar = document.createElement("nav");
+      tocContainerInSidebar.classList.add("nav-list", "nav-list--toc");
+      tocContainerInSidebar.appendChild(tocTitleElement);
+      tocContainerInSidebar.appendChild(clonedThemeToc);
+
+      const activeListItem = sidebar.querySelector(".nav-list-item.active");
+      if (activeListItem) {
+        activeListItem.appendChild(tocContainerInSidebar);
+      } else {
+        sidebar.appendChild(tocContainerInSidebar);
+        console.warn("Sidebar ToC: No active .nav-list-item found for theme .toc. Appending ToC to end of sidebar.");
+      }
+      document.body.classList.add("js-toc-sidebar"); // Still hide original .toc
     }
   }
 });
@@ -88,28 +121,40 @@ body.js-toc-sidebar .main-content-wrap .toc {
 }
 
 /* Styling for different heading levels based on nesting */
-/* Level 1 (top-most UL in .toc-in-sidebar) */
-.toc-in-sidebar > ul > li > a {
-  font-weight: bold; /* Make top-level ToC items bold */
+/* .toc-in-sidebar is the main UL (ul#markdown-toc) */
+
+/* Level 1 links (direct li children of .toc-in-sidebar) */
+.toc-in-sidebar > li > a {
+  font-weight: bold;
   font-size: 1em; /* Relative to .nav-list--toc font-size (0.9rem) */
 }
 
-/* Level 2 (first nested UL) */
-.toc-in-sidebar > ul > li > ul > li > a {
+/* Level 2 links (links within the first level of nested ULs) */
+.toc-in-sidebar > li > ul > li > a {
   font-size: 0.95em;
 }
 
-/* Level 3 (second nested UL) */
-.toc-in-sidebar > ul > li > ul > li > ul > li > a {
+/* Level 3 links */
+.toc-in-sidebar > li > ul > li > ul > li > a {
   font-size: 0.9em;
-  /* color: var(--jtc-text-color-light); */ /* Example for lighter color for deeper levels */
+  /* color: var(--jtc-text-color-light); */
 }
 
-/* Level 4 (third nested UL) */
-.toc-in-sidebar > ul > li > ul > li > ul > li > ul > li > a {
+/* Level 4 links */
+.toc-in-sidebar > li > ul > li > ul > li > ul > li > a {
   font-size: 0.85em;
   /* color: var(--jtc-text-color-lighter); */
 }
-/* Add more levels if needed */
+
+/* Level 5 links */
+.toc-in-sidebar > li > ul > li > ul > li > ul > li > ul > li > a {
+  font-size: 0.80em;
+}
+
+/* Level 6 links */
+.toc-in-sidebar > li > ul > li > ul > li > ul > li > ul > li > ul > li > a {
+  font-size: 0.75em;
+}
+/* Note: Indentation is handled by .toc-in-sidebar ul ul { padding-left: 0.75rem; } */
 
 </style>


### PR DESCRIPTION
- Modifies the JavaScript in `_includes/head_custom.html` to prioritize finding `ul#markdown-toc` (generated by user's in-page `{:toc}`).
- If `ul#markdown-toc` is found, it is moved to the sidebar (not cloned), and its original parent `<details>` container is hidden.
- The `toc-in-sidebar` class is added to the moved `ul#markdown-toc` for styling.
- If `ul#markdown-toc` is not found, the script falls back to the previous logic of finding and cloning a general `.toc` element (theme's default ToC).
- CSS selectors for hierarchical styling in the sidebar ToC were updated to correctly target the structure when `ul#markdown-toc` is used directly.