### PR TITLE
Fix: Remove dead script reference to page-toc.js

### DIFF
--- a/_includes/footer_custom.html
+++ b/_includes/footer_custom.html
@@ -1,1 +1,0 @@
-<script src="{{ '/assets/js/page-toc.js' | relative_url }}"></script>


### PR DESCRIPTION
- Deleted `_includes/footer_custom.html` which contained a script tag referencing the previously deleted `assets/js/page-toc.js`.
- This removes a potential source of JavaScript errors (404 for the missing script) that could interfere with other page scripts, including the current sidebar ToC generation logic in `_includes/head_custom.html`.